### PR TITLE
fixed `props_assignments_10.fixture.php` test fail

### DIFF
--- a/src/test/fixtures/strict_typing/props_assignments_10.fixture.php
+++ b/src/test/fixtures/strict_typing/props_assignments_10.fixture.php
@@ -17,8 +17,7 @@ class A {
     public $var;
 }
 
-// while running tests, standard library is not included
-// so, write prototypes of functions we are testing
+// prototypes of kphp build-in functions we are testing
 if(0) {
     function array_first_value(array &$a) { $r = current($a); return ${'r'}; }
     function array_last_value(array &$a) { $r = current(${'a'}); return ${'a'}; }

--- a/src/test/fixtures/strict_typing/props_assignments_10.fixture.php
+++ b/src/test/fixtures/strict_typing/props_assignments_10.fixture.php
@@ -17,7 +17,7 @@ class A {
     public $var;
 }
 
-// prototypes of kphp build-in functions we are testing
+// prototypes of kphp built-in functions we are testing
 if(0) {
     function array_first_value(array &$a) { $r = current($a); return ${'r'}; }
     function array_last_value(array &$a) { $r = current(${'a'}); return ${'a'}; }

--- a/src/test/fixtures/strict_typing/props_assignments_10.fixture.php
+++ b/src/test/fixtures/strict_typing/props_assignments_10.fixture.php
@@ -20,22 +20,6 @@ class A {
 // while running tests, standard library is not included
 // so, write prototypes of functions we are testing
 if(0) {
-    /** @return string|null */
-    function bcdiv(string $s1, string $s2) {}
-    /** @return string|null */
-    function bcmod(string $s1, string $s2) {}
-    /** @return unknown */
-    function unserialize(string $str) {}
-    /** @return any */
-    function json_decode(string $str) {}
-    /** @return string|string[] */
-    function str_replace($search, $replace, $subject) {}
-    /** @return string|string[] */
-    function substr_replace($string, $replacement, $start, $length = 0) {}
-
-    function array_filter(array $a, ?callable $c = null) { return ${'a'}; }
-    function array_values(array $a) { return ${'a'}; }
-
     function array_first_value(array &$a) { $r = current($a); return ${'r'}; }
     function array_last_value(array &$a) { $r = current(${'a'}); return ${'a'}; }
     function array_filter_by_key(array &$a, callable $callback) { return ${'a'}; }
@@ -89,7 +73,7 @@ function demo() {
     $a->s_arr[] = $s_arr[0];
     $a->s_arr = str_replace('search', 'replace', getSArr());
 
-    <error descr="Can't assign 'int|bool' to 'string' $s">$a->s = str_replace('s', 'r', getTrash())</error>;
+    <error descr="Can't assign 'int' to 'string' $s">$a->s = str_replace('s', 'r', getTrash())</error>;
 }
 
 function demo2() {
@@ -97,8 +81,8 @@ function demo2() {
     $a->s = array_first_value($a->s_arr);
     <error descr="Can't assign 'string' to 'A' $a">$a->a = array_first_value($a->s_arr)</error>;
     $a->s_arr[] = array_last_value($a->s_arr);
-    <error descr="Can't assign 'mixed' to 'string' $s">$a->s = array_first_value($a->var)</error>;
-    <error descr="Can't assign 'mixed' to 'A' $a">$a->a = array_first_value($a->var)</error>;
+    <error descr="Can't assign 'mixed|any' to 'string' $s">$a->s = array_first_value($a->var)</error>;
+    <error descr="Can't assign 'mixed|any' to 'A' $a">$a->a = array_first_value($a->var)</error>;
     $a->var = array_first_value($a->var);
     $a->s_arr = array_filter_by_key($a->s_arr, function($k) { return true; });
     <error descr="Can't assign 'int[]' to 'string[]' $s_arr">$a->s_arr = array_filter_by_key($a->i_arr, function($k) { return true; })</error>;


### PR DESCRIPTION
Apparently, in 2022.1 in stubs, the `str_replace` function no longer returns bool, so the test failed.

Also `array_first_value` which is handled manually now returns `any` in some cases when it cannot infer the type of the passed array. This is logical and strange why the function earlier return only the mixed type.