### PR TITLE
added extension helper to PhpPsiBuilder

### DIFF
--- a/src/main/kotlin/com/vk/kphpstorm/helpers/PsiTreeExtensions.kt
+++ b/src/main/kotlin/com/vk/kphpstorm/helpers/PsiTreeExtensions.kt
@@ -3,10 +3,12 @@ package com.vk.kphpstorm.helpers
 import com.intellij.openapi.editor.CaretState
 import com.intellij.openapi.editor.Editor
 import com.intellij.psi.PsiElement
+import com.intellij.psi.tree.IElementType
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
 import com.jetbrains.php.lang.documentation.phpdoc.psi.PhpDocComment
 import com.jetbrains.php.lang.parser.PhpElementTypes
+import com.jetbrains.php.lang.parser.PhpPsiBuilder
 import com.jetbrains.php.lang.psi.elements.Field
 import com.jetbrains.php.lang.psi.elements.Function
 import com.jetbrains.php.lang.psi.elements.PhpClass
@@ -48,4 +50,30 @@ fun setSelectionInEditor(editor: Editor, elementToSelect: PsiElement) {
             editor.offsetToLogicalPosition(offset),
             editor.offsetToLogicalPosition(offset + elementToSelect.textLength)
     ))
+}
+
+/**
+ * Example:
+ *
+ * ```
+ *  builder.compare(token1, token2, ...etc)
+ *  // equivalent to
+ *  builder.compare(token1) || builder.compare(token2) || etc
+ *  ```
+ */
+fun PhpPsiBuilder.compareAny(vararg tokens: IElementType): Boolean {
+    return tokens.any { this.compare(it) }
+}
+
+/**
+ * Example:
+ *
+ * ```
+ *  builder.compareAndEatAny(token1, token2, ...etc)
+ *  // equivalent to
+ *  builder.compareAndEatAny(token1) || builder.compareAndEatAny(token2) || etc
+ *  ```
+ */
+fun PhpPsiBuilder.compareAndEatAny(vararg tokens: IElementType): Boolean {
+    return tokens.any { this.compareAndEat(it) }
 }

--- a/src/main/kotlin/com/vk/kphpstorm/kphptags/psi/KphpDocTagWarnPerformanceElementType.kt
+++ b/src/main/kotlin/com/vk/kphpstorm/kphptags/psi/KphpDocTagWarnPerformanceElementType.kt
@@ -10,6 +10,7 @@ import com.jetbrains.php.lang.documentation.phpdoc.psi.tags.PhpDocTag
 import com.jetbrains.php.lang.parser.PhpParserErrors
 import com.jetbrains.php.lang.parser.PhpPsiBuilder
 import com.jetbrains.php.lang.psi.stubs.PhpStubElementType
+import com.vk.kphpstorm.helpers.compareAny
 
 object KphpDocTagWarnPerformanceElementType : PhpStubElementType<PhpDocTagStub, PhpDocTag>("@kphp-warn-performance"), KphpDocTagElementType {
     override fun createPsi(stub: PhpDocTagStub): PhpDocTag {
@@ -41,7 +42,7 @@ object KphpDocTagWarnPerformanceElementType : PhpStubElementType<PhpDocTagStub, 
 
         override fun parseContents(builder: PhpPsiBuilder): Boolean {
             do {
-                if (builder.compare(PhpDocTokenTypes.DOC_LEADING_ASTERISK) || builder.compare(PhpDocTokenTypes.DOC_COMMENT_END))
+                if (builder.compareAny(PhpDocTokenTypes.DOC_LEADING_ASTERISK, PhpDocTokenTypes.DOC_COMMENT_END))
                     break
 
                 val marker = builder.mark()


### PR DESCRIPTION
Instead of writing
```kotlin
builder.compare(PhpTokenTypes.kwCLASS) || builder.compare(PhpTokenTypes.kwTRAIT) ||
builder.compare(PhpTokenTypes.kwABSTRACT) || builder.compare(PhpTokenTypes.kwFINAL)
```

It will be possible to write
```kotlin
builder.compareAny(
    PhpTokenTypes.kwCLASS, PhpTokenTypes.kwTRAIT,
    PhpTokenTypes.kwABSTRACT, PhpTokenTypes.kwFINAL,
)
```