### PR TITLE
fixed PHP 7.4 version for tests by default

### DIFF
--- a/src/test/fixtures/strict_typing/return_mismatch.fixture.php
+++ b/src/test/fixtures/strict_typing/return_mismatch.fixture.php
@@ -51,7 +51,7 @@ function withLambdas() {
     };
 
     $f2 = function(): void {
-        <error descr="Can't return 'string', expected 'void'">return 'asdf';</error>
+        <error descr="Can't return 'string', expected 'void'">return <error descr="A void function must not return a value">'asdf'</error>;</error>
     };
 
     // this is ok, because lambdas are not typed, so if not declared - void is not assumed
@@ -71,6 +71,6 @@ function withLambdas() {
     };
 
     $f6 = function($untyped): void {
-        return $untyped;
+        return <error descr="A void function must not return a value">$untyped</error>;
     };
 }

--- a/src/test/fixtures/strict_typing/return_statement_1.fixture.php
+++ b/src/test/fixtures/strict_typing/return_statement_1.fixture.php
@@ -33,7 +33,7 @@ function getInt6() : int {
 }
 
 function getInt7() : void {
-    <error descr="Can't return 'int', expected 'void'">return 5;</error>
+    <error descr="Can't return 'int', expected 'void'">return <error descr="A void function must not return a value">5</error>;</error>
 }
 
 function getInt8() : int {

--- a/src/test/fixtures/strict_typing/return_statement_8.fixture.php
+++ b/src/test/fixtures/strict_typing/return_statement_8.fixture.php
@@ -19,5 +19,5 @@ function demo3(int $a) {
 }
 
 function demo4(): void {
-    <error descr="Can't return 'int', expected 'void'">return 123;</error>
+    <error descr="Can't return 'int', expected 'void'">return <error descr="A void function must not return a value">123</error>;</error>
 }

--- a/src/test/kotlin/com/vk/kphpstorm/testing/infrastructure/InspectionTestBase.kt
+++ b/src/test/kotlin/com/vk/kphpstorm/testing/infrastructure/InspectionTestBase.kt
@@ -1,6 +1,8 @@
 package com.vk.kphpstorm.testing.infrastructure
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.jetbrains.php.config.PhpLanguageLevel
+import com.jetbrains.php.config.PhpProjectConfigurationFacade
 import com.jetbrains.php.lang.inspections.PhpInspection
 import com.vk.kphpstorm.configuration.KphpStormConfiguration
 import java.io.File
@@ -10,6 +12,8 @@ abstract class InspectionTestBase(
         private val inspectionToEnable: PhpInspection
 ) : BasePlatformTestCase() {
 
+    open val languageLevel: PhpLanguageLevel = PhpLanguageLevel.PHP740
+
     override fun getTestDataPath() = "src/test/fixtures"
 
     override fun setUp() {
@@ -18,11 +22,18 @@ abstract class InspectionTestBase(
         myFixture.enableInspections(inspectionToEnable)
     }
 
+    private fun setupLanguageLevel() {
+        val projectConfigurationFacade = PhpProjectConfigurationFacade.getInstance(project)
+        projectConfigurationFacade.languageLevel = languageLevel
+    }
+
     /**
      * Run inspection on file.fixture.php and check that all <warning> and <error> match
      * If file.qf.php exists, apply quickfixes and compare result to file.qf.php
      */
     protected fun runFixture(fixtureFile: String) {
+        setupLanguageLevel()
+
         // Highlighting test
         KphpStormConfiguration.saveThatSetupForProjectDone(project)
         myFixture.configureByFile(fixtureFile)

--- a/src/test/kotlin/com/vk/kphpstorm/testing/infrastructure/IntentionTestBase.kt
+++ b/src/test/kotlin/com/vk/kphpstorm/testing/infrastructure/IntentionTestBase.kt
@@ -2,6 +2,8 @@ package com.vk.kphpstorm.testing.infrastructure
 
 import com.intellij.codeInsight.intention.IntentionAction
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.jetbrains.php.config.PhpLanguageLevel
+import com.jetbrains.php.config.PhpProjectConfigurationFacade
 import com.vk.kphpstorm.configuration.KphpStormConfiguration
 
 
@@ -9,13 +11,22 @@ abstract class IntentionTestBase(
         private val intentionToExecute: IntentionAction
 ) : BasePlatformTestCase() {
 
+    open val languageLevel: PhpLanguageLevel = PhpLanguageLevel.PHP740
+
     override fun getTestDataPath() = "src/test/fixtures"
+
+    private fun setupLanguageLevel() {
+        val projectConfigurationFacade = PhpProjectConfigurationFacade.getInstance(project)
+        projectConfigurationFacade.languageLevel = languageLevel
+    }
 
     /**
      * Run intention on file.fixture.php at place marked <caret>
      * file.qf.php must exist, the result of applying intention is compared to its contents
      */
     protected fun runIntention(fixtureFile: String) {
+        setupLanguageLevel()
+
         KphpStormConfiguration.saveThatSetupForProjectDone(project)
         myFixture.configureByFile(fixtureFile)
         myFixture.launchAction(myFixture.findSingleIntention(intentionToExecute.familyName))


### PR DESCRIPTION
By default, PhpStorm uses PHP 5.6 in the tests, however, all our code… is written under 7.4, so this must be explicitly fixed.

New errors found in the tests are the result of the annotator's work and aren't actual inspections.

See https://youtrack.jetbrains.com/issue/WI-67021/During-a-test-primitive-type-hints-are-resolved-as-instances

See #12